### PR TITLE
Updating default template to include metadata.rb and templates

### DIFF
--- a/lib/guard/foodcritic/templates/Guardfile
+++ b/lib/guard/foodcritic/templates/Guardfile
@@ -3,4 +3,6 @@ guard "foodcritic" do
   watch(%r{providers/.+\.rb$})
   watch(%r{recipes/.+\.rb$})
   watch(%r{resources/.+\.rb$})
+  watch(%r{templates/.+$})
+  watch['metadata.rb']
 end


### PR DESCRIPTION
There are a few Foodcritic rules that cover the metadata.rb file and template files that aren't covered by the existing matchers. This adds matchers for both.

Templates
---------------
FC034: Unused template variables

Metadata.rb
-----------------
FC007: Ensure recipe dependencies are reflected in cookbook metadata
FC008: Generated cookbook metadata needs updating
FC031: Cookbook without metadata file