### PR TITLE
Upgrade for Guard v2 API

### DIFF
--- a/guard-foodcritic.gemspec
+++ b/guard-foodcritic.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.version       = Guard::FOODCRITIC_VERSION
 
-  gem.add_runtime_dependency "guard", ">= 1.0", "< 3.0"
+  gem.add_runtime_dependency "guard", ">= 2.0", "< 3.0"
   gem.add_runtime_dependency "foodcritic", ">= 1.3", "< 5.0"
 
   gem.add_development_dependency "bundler", "~> 1.0"

--- a/lib/guard/foodcritic.rb
+++ b/lib/guard/foodcritic.rb
@@ -1,11 +1,10 @@
 require "guard"
-require "guard/guard"
 
 module Guard
-  class Foodcritic < Guard
+  class Foodcritic < Plugin
     autoload :Runner, "guard/foodcritic/runner"
 
-    def initialize(watchers=[], options={})
+    def initialize(options={})
       super
 
       @options = {

--- a/spec/guard/foodcritic_spec.rb
+++ b/spec/guard/foodcritic_spec.rb
@@ -8,7 +8,7 @@ module Guard
       UI.stub(:info)
     end
 
-    it { should be_a_kind_of ::Guard::Guard }
+    it { should be_a_kind_of ::Guard::Plugin }
 
     describe "#options" do
       it "[:all_on_start] defaults to true" do
@@ -74,7 +74,7 @@ module Guard
 
     describe "#run_all" do
       subject { guard.run_all }
-      let(:guard) { described_class.new [], :cookbook_paths => %w(cookbooks site-cookbooks), :notification => notification }
+      let(:guard) { described_class.new :cookbook_paths => %w(cookbooks site-cookbooks), :notification => notification }
       let(:notification) { false }
       let(:runner) { double "runner", :run => true }
       before { guard.stub(:runner).and_return(runner) }
@@ -93,7 +93,7 @@ module Guard
     end
 
     shared_examples "lints specified cookbook files" do
-      let(:guard) { described_class.new([], :notification => notification) }
+      let(:guard) { described_class.new(:notification => notification) }
       let(:notification) { false }
       let(:paths) { %w(recipes/default.rb attributes/default.rb) }
       let(:runner) { double "runner", :run => true }
@@ -146,13 +146,13 @@ module Guard
 
     describe "#start" do
       it "runs all on start if the :all_on_start option is set to true" do
-        guard = described_class.new([], :all_on_start => true)
+        guard = described_class.new(:all_on_start => true)
         guard.should_receive(:run_all)
         guard.start
       end
 
       it "does not run all on start if the :all_on_start option is set to false" do
-        guard = described_class.new([], :all_on_start => false)
+        guard = described_class.new(:all_on_start => false)
         guard.should_not_receive(:run_all)
         guard.start
       end


### PR DESCRIPTION
This is a very quick application of the upgrade instructions on the Guard Wiki here:

https://github.com/guard/guard/wiki/Upgrading-to-Guard-2.0

* change inheritance to be Guard::Plugin instead of Guard::Guard
* remove watchers array from constructor call in specs
* make runtime dependency on guard >= 2.0, <= 3.0

I didn't add any new tests, but all existing specs pass.