### PR TITLE
Release 1.10

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,2 +1,2 @@
 --color
---format nested
+--format doc

--- a/.rubocop.todo.yml
+++ b/.rubocop.todo.yml
@@ -1,0 +1,11 @@
+Style/HashSyntax:
+  Enabled: false
+
+Metrics/LineLength:
+  Max: 100
+
+Style/Documentation:
+  Enabled: false
+
+Metrics/ModuleLength:
+  Max: 137

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,1 @@
+inherit_from: .rubocop.todo.yml

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,11 @@
 language: ruby
 rvm:
-  - 1.9.3
-  - 2.0.0
-  - 2.1
-bundler_args: --without development
+  - "1.9.3-p551"
+  - "2.0.0-p598"
+  - "2.1.6"
+  - "2.2.2"
+install: bundle install --binstubs
+env: TRAVIS_BUILD=true
+matrix:
+  allow_failures:
+    - rvm: "1.9.3-p551"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Project History for guard-foodcritic
+
+## 1.1.0
+
+* merge PR from Nordstrom to make compatible with Guard 2.9 and higher (PR )
+* update dependencies to latest Guard and Foodcritic versions
+* adapt Richard Nixon's (@trickyearlobe) PR to bring in guard-compat to fix test suite
+* first pass at cleaning up Rubocop style issues
+* extend Travis-CI matrix to ruby 1.9.3, 2.0.0, 2.1.6 and 2.2.2
+* maintainership transferred to Nordstrom, Inc.
+
+## 1.0.3
+
+* a changelog was not maintained for 1.0.3 or older; we may rebuild this from git changelogs

--- a/Gemfile
+++ b/Gemfile
@@ -1,11 +1,3 @@
-source "https://rubygems.org"
+source 'https://rubygems.org'
 
 gemspec :development_group => :test
-
-group :development do
-  gem "growl"
-  gem "guard-bundler"
-  gem "guard-rspec"
-  gem "rb-fsevent"
-  gem "travis-lint"
-end

--- a/Guardfile
+++ b/Guardfile
@@ -1,11 +1,6 @@
-guard "bundler" do
-  watch("Gemfile")
-  watch(/^.+\.gemspec/)
-end
-
-guard "rspec", :version => 2, :cli=> "--format nested" do
+guard 'rspec', :version => 2, :cli => '--format doc' do
   watch(%r{^spec/.+_spec\.rb$})
   watch(%r{^lib/(.+)\.rb$}) { |m| "spec/#{m[1]}_spec.rb" }
-  watch("spec/spec_helper.rb") { "spec" }
-  watch(%r{^spec/support/(.+)\.rb$}) { |m| "spec" }
+  watch('spec/spec_helper.rb') { 'spec' }
+  watch(%r{^spec/support/(.+)\.rb$}) { |_| 'spec' }
 end

--- a/README.md
+++ b/README.md
@@ -1,13 +1,14 @@
 # Guard::Foodcritic
 
-[![Build History][2]][1] [![Dependency Status][4]][3]
+[![Gem Version](https://badge.fury.io/rb/guard-foodcritic.png)](http://badge.fury.io/rb/guard-foodcritic)
+
+[![Build Status](https://travis-ci.org/Nordstrom/guard-foodcritic.png?branch=master)](https://travis-ci.org/Nordstrom/guard-foodcritic)
+
+[![Inline docs](http://inch-ci.org/github/nordstrom/guard-foodcritic.svg?branch=master)](http://inch-ci.org/github/nordstrom/guard-foodcritic)
+
+[![Code Climate](https://codeclimate.com/github/Nordstrom/guard-foodcritic/badges/gpa.svg)](https://codeclimate.com/github/Nordstrom/guard-foodcritic)
 
 Guard::Foodcritic automatically runs foodcritic.
-
-[1]: http://travis-ci.org/cgriego/guard-foodcritic
-[2]: https://secure.travis-ci.org/cgriego/guard-foodcritic.png?branch=master
-[3]: https://gemnasium.com/cgriego/guard-foodcritic
-[4]: https://gemnasium.com/cgriego/guard-foodcritic.png
 
 ## Installation
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,6 @@
 #!/usr/bin/env rake
-require "bundler/gem_tasks"
-require "rspec/core/rake_task"
+require 'bundler/gem_tasks'
+require 'rspec/core/rake_task'
 
 task :default => :spec
 

--- a/guard-foodcritic.gemspec
+++ b/guard-foodcritic.gemspec
@@ -2,23 +2,23 @@
 require File.expand_path('../lib/guard/foodcritic/version', __FILE__)
 
 Gem::Specification.new do |gem|
-  gem.authors       = ["Chris Griego"]
-  gem.email         = ["cgriego@gmail.com"]
-  gem.description   = %q{Guard::Foodcritic automatically runs foodcritic.}
-  gem.summary       = %q{Guard::Foodcritic automatically runs foodcritic.}
-  gem.homepage      = "https://github.com/cgriego/guard-foodcritic"
+  gem.authors       = ['Chris Griego', 'James FitzGibbon']
+  gem.email         = ['cgriego@gmail.com', 'james.i.fitzgibbon@nordstrom.com']
+  gem.description   = 'Guard::Foodcritic automatically runs foodcritic.'
+  gem.summary       = 'Guard::Foodcritic automatically runs foodcritic.'
+  gem.homepage      = 'https://github.com/Nordstrom/guard-foodcritic'
 
-  gem.files         = `git ls-files`.split($\)
+  gem.files         = `git ls-files`.split($OUTPUT_RECORD_SEPARATOR)
   gem.executables   = gem.files.grep(%r{^bin/}).map { |f| File.basename(f) }
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
-  gem.name          = "guard-foodcritic"
-  gem.require_paths = ["lib"]
+  gem.name          = 'guard-foodcritic'
+  gem.require_paths = ['lib']
   gem.version       = Guard::FOODCRITIC_VERSION
 
-  gem.add_runtime_dependency "guard", ">= 2.0", "< 3.0"
-  gem.add_runtime_dependency "foodcritic", ">= 1.3", "< 5.0"
+  gem.add_runtime_dependency 'guard', '~> 2.12'
+  gem.add_dependency 'guard-compat', '~> 1.1'
+  gem.add_runtime_dependency 'foodcritic', '~> 4.0'
 
-  gem.add_development_dependency "bundler", "~> 1.0"
-  gem.add_development_dependency "rake", "~> 10.0"
-  gem.add_development_dependency "rspec", "~> 2.10"
+  gem.add_development_dependency 'rake', '~> 10.0'
+  gem.add_development_dependency 'rspec', '~> 2.10'
 end

--- a/lib/guard/foodcritic.rb
+++ b/lib/guard/foodcritic.rb
@@ -1,16 +1,16 @@
-require "guard"
+require 'guard/compat/plugin'
 
 module Guard
   class Foodcritic < Plugin
-    autoload :Runner, "guard/foodcritic/runner"
+    autoload :Runner, 'guard/foodcritic/runner'
 
-    def initialize(options={})
+    def initialize(options = {})
       super
 
       @options = {
         :all_on_start => true,
-        :cookbook_paths => ["cookbooks"],
-        :notification => true,
+        :cookbook_paths => ['cookbooks'],
+        :notification => true
       }.merge(@options)
     end
 
@@ -23,7 +23,7 @@ module Guard
     end
 
     def run_all
-      UI.info "Linting all cookbooks"
+      Guard::Compat::UI.info 'Linting all cookbooks'
       run! @options[:cookbook_paths]
     end
 
@@ -39,7 +39,7 @@ module Guard
       run_paths paths
     end
 
-    def respond_to?(method_name, include_private=false)
+    def respond_to?(method_name, include_private = false)
       if %w(run_on_deletion run_on_change).include? method_name.to_s
         false
       else
@@ -50,15 +50,15 @@ module Guard
     private
 
     def run_paths(paths)
-      UI.info "Linting: #{paths.join(' ')}"
+      Guard::Compat::UI.info "Linting: #{paths.join(' ')}"
       run! paths
     end
 
     def run!(paths)
       if runner.run(paths)
-        Notifier.notify "Foodcritic passed", :image => :success if @options[:notification]
+        Guard::Compat::UI.notify 'Foodcritic passed', :image => :success if @options[:notification]
       else
-        Notifier.notify "Foodcritic failed", :image => :failed if @options[:notification]
+        Guard::Compat::UI.notify 'Foodcritic failed', :image => :failed if @options[:notification]
         throw :task_has_failed
       end
     end

--- a/lib/guard/foodcritic/runner.rb
+++ b/lib/guard/foodcritic/runner.rb
@@ -1,18 +1,18 @@
-require "guard/foodcritic"
+require 'guard/foodcritic'
 
 module Guard
   class Foodcritic
     class Runner
       attr_reader :options
 
-      def initialize(options={})
+      def initialize(options = {})
         @options = {
-          :cli => "--epic-fail any",
+          :cli => '--epic-fail any'
         }.merge(options)
       end
 
       def command(paths)
-        ["foodcritic", @options[:cli], paths].flatten(1).join(' ')
+        ['foodcritic', @options[:cli], paths].flatten(1).join(' ')
       end
 
       def run(paths)

--- a/lib/guard/foodcritic/templates/Guardfile
+++ b/lib/guard/foodcritic/templates/Guardfile
@@ -1,4 +1,4 @@
-guard "foodcritic" do
+guard 'foodcritic' do
   watch(%r{attributes/.+\.rb$})
   watch(%r{providers/.+\.rb$})
   watch(%r{recipes/.+\.rb$})

--- a/lib/guard/foodcritic/version.rb
+++ b/lib/guard/foodcritic/version.rb
@@ -1,3 +1,3 @@
 module Guard
-  FOODCRITIC_VERSION = "1.0.3"
+  FOODCRITIC_VERSION = '1.1.0'
 end

--- a/spec/guard/foodcritic/runner_spec.rb
+++ b/spec/guard/foodcritic/runner_spec.rb
@@ -1,56 +1,57 @@
-require "spec_helper"
-require "guard/foodcritic/runner"
+require 'spec_helper'
+require 'guard/compat/test/helper'
+require 'guard/foodcritic/runner'
 
 module Guard
   describe Foodcritic::Runner do
-    describe "#options" do
-      it "remembers the initialized options" do
-        options = { :foo => "bar" }
+    describe '#options' do
+      it 'remembers the initialized options' do
+        options = { :foo => 'bar' }
         described_class.new(options).options.should include options
       end
 
       it "[:cli] defaults to '--epic-fail any'" do
-        described_class.new.options[:cli].should == "--epic-fail any"
+        described_class.new.options[:cli].should == '--epic-fail any'
       end
     end
 
-    describe "#command" do
+    describe '#command' do
       let(:runner) { described_class.new }
       let(:paths) { %w(recipes/default.rb attributes/default.rb) }
       subject { runner.command(paths) }
 
-      it "calls the foodcritic executable" do
-        should start_with "foodcritic"
+      it 'calls the foodcritic executable' do
+        should start_with 'foodcritic'
       end
 
-      it "passes the given paths to the foodcritic executable" do
-        should end_with paths.join(" ")
+      it 'passes the given paths to the foodcritic executable' do
+        should end_with paths.join(' ')
       end
 
-      it "includes the cli option" do
+      it 'includes the cli option' do
         should include runner.options[:cli]
       end
     end
 
-    describe "#run" do
+    describe '#run' do
       let(:runner) { described_class.new }
-      let(:command) { double "command" }
+      let(:command) { double 'command' }
       before { runner.stub(:command).and_return(command) }
 
-      it "generates the command with the given paths and runs it" do
+      it 'generates the command with the given paths and runs it' do
         paths = %w(recipes/default.rb attributes/default.rb)
         runner.should_receive(:system).with(command)
         runner.run(paths)
       end
 
-      it "returns true when foodcritic suceeds" do
+      it 'returns true when foodcritic suceeds' do
         runner.stub(:system).and_return(true)
-        runner.run([]).should be_true
+        runner.run([]).should be true
       end
 
-      it "returns false when foodcritic finds fault" do
+      it 'returns false when foodcritic finds fault' do
         runner.stub(:system).and_return(false)
-        runner.run([]).should be_false
+        runner.run([]).should be false
       end
     end
   end

--- a/spec/guard/foodcritic_spec.rb
+++ b/spec/guard/foodcritic_spec.rb
@@ -1,5 +1,6 @@
-require "spec_helper"
-require "guard/foodcritic"
+require 'spec_helper'
+require 'guard/compat/test/helper'
+require 'guard/foodcritic'
 
 module Guard
   describe Foodcritic do
@@ -10,61 +11,61 @@ module Guard
 
     it { should be_a_kind_of ::Guard::Plugin }
 
-    describe "#options" do
-      it "[:all_on_start] defaults to true" do
-        described_class.new.options[:all_on_start].should be_true
+    describe '#options' do
+      it '[:all_on_start] defaults to true' do
+        described_class.new.options[:all_on_start].should be true
       end
 
       it "[:cookbook_paths] defaults to ['cookbooks']" do
-        described_class.new.options[:cookbook_paths].should == ["cookbooks"]
+        described_class.new.options[:cookbook_paths].should == ['cookbooks']
       end
 
-      it "[:notification] defaults to true" do
-        described_class.new.options[:notification].should be_true
+      it '[:notification] defaults to true' do
+        described_class.new.options[:notification].should be true
       end
     end
 
-    shared_examples "handles runner results" do
-      context "the runner fails" do
+    shared_examples 'handles runner results' do
+      context 'the runner fails' do
         before { runner.stub(:run).and_return(false) }
         it { expect { subject }.to throw_symbol :task_has_failed }
 
-        context "notifications are enabled" do
+        context 'notifications are enabled' do
           let(:notification) { true }
 
-          it "notifies the user of the failure" do
-            Notifier.should_receive(:notify).with("Foodcritic failed", :image => :failed)
+          it 'notifies the user of the failure' do
+            Notifier.should_receive(:notify).with('Foodcritic failed', :image => :failed)
             catch(:task_has_failed) { subject }
           end
         end
 
-        context "notifications are disabled" do
+        context 'notifications are disabled' do
           let(:notification) { false }
 
-          it "does not notify the user of the failure" do
+          it 'does not notify the user of the failure' do
             Notifier.should_not_receive(:notify)
             catch(:task_has_failed) { subject }
           end
         end
       end
 
-      context "the runner succeeds" do
+      context 'the runner succeeds' do
         before { runner.stub(:run).and_return(true) }
         it { expect { subject }.not_to throw_symbol :task_has_failed }
 
-        context "notifications are enabled" do
+        context 'notifications are enabled' do
           let(:notification) { true }
 
-          it "notifies the user of the success" do
-            Notifier.should_receive(:notify).with("Foodcritic passed", :image => :success)
+          it 'notifies the user of the success' do
+            Notifier.should_receive(:notify).with('Foodcritic passed', :image => :success)
             subject
           end
         end
 
-        context "notifications are disabled" do
+        context 'notifications are disabled' do
           let(:notification) { false }
 
-          it "does not notify the user of the success" do
+          it 'does not notify the user of the success' do
             Notifier.should_not_receive(:notify)
             subject
           end
@@ -72,93 +73,98 @@ module Guard
       end
     end
 
-    describe "#run_all" do
+    describe '#run_all' do
       subject { guard.run_all }
-      let(:guard) { described_class.new :cookbook_paths => %w(cookbooks site-cookbooks), :notification => notification }
+      let(:guard) do
+        described_class.new(
+          :cookbook_paths => %w(cookbooks site-cookbooks),
+          :notification => notification
+        )
+      end
       let(:notification) { false }
-      let(:runner) { double "runner", :run => true }
+      let(:runner) { double 'runner', :run => true }
       before { guard.stub(:runner).and_return(runner) }
 
-      it "runs the runner with the cookbook paths" do
+      it 'runs the runner with the cookbook paths' do
         runner.should_receive(:run).with(guard.options[:cookbook_paths]).and_return(true)
         subject
       end
 
-      it "informs the user" do
-        UI.should_receive(:info).with("Linting all cookbooks")
+      it 'informs the user' do
+        UI.should_receive(:info).with('Linting all cookbooks', {})
         subject
       end
 
-      include_examples "handles runner results"
+      include_examples 'handles runner results'
     end
 
-    shared_examples "lints specified cookbook files" do
+    shared_examples 'lints specified cookbook files' do
       let(:guard) { described_class.new(:notification => notification) }
       let(:notification) { false }
       let(:paths) { %w(recipes/default.rb attributes/default.rb) }
-      let(:runner) { double "runner", :run => true }
+      let(:runner) { double 'runner', :run => true }
       before { guard.stub(:runner).and_return(runner) }
 
-      it "runs the runner with the changed paths" do
+      it 'runs the runner with the changed paths' do
         runner.should_receive(:run).with(paths).and_return(true)
         subject
       end
 
-      it "informs the user" do
-        UI.should_receive(:info).with("Linting: recipes/default.rb attributes/default.rb")
+      it 'informs the user' do
+        UI.should_receive(:info).with('Linting: recipes/default.rb attributes/default.rb', {})
         subject
       end
 
-      include_examples "handles runner results"
+      include_examples 'handles runner results'
     end
 
-    describe "#run_on_additions" do
+    describe '#run_on_additions' do
       subject { guard.run_on_additions(paths) }
-      include_examples "lints specified cookbook files"
+      include_examples 'lints specified cookbook files'
     end
 
-    describe "#run_on_change" do
+    describe '#run_on_change' do
       subject { guard.run_on_change(paths) }
-      include_examples "lints specified cookbook files"
+      include_examples 'lints specified cookbook files'
     end
 
-    describe "#run_on_modifications" do
+    describe '#run_on_modifications' do
       subject { guard.run_on_modifications(paths) }
-      include_examples "lints specified cookbook files"
+      include_examples 'lints specified cookbook files'
     end
 
-    describe "#runner" do
-      it "returns a Runner" do
+    describe '#runner' do
+      it 'returns a Runner' do
         described_class.new.runner.should be_a_kind_of Foodcritic::Runner
       end
 
-      it "memoizes the runner" do
+      it 'memoizes the runner' do
         guard = described_class.new
         guard.runner.should equal guard.runner
       end
 
-      it "configured the runner with the guard options" do
+      it 'configured the runner with the guard options' do
         guard = described_class.new
         runner = guard.runner
         runner.options.should include guard.options
       end
     end
 
-    describe "#start" do
-      it "runs all on start if the :all_on_start option is set to true" do
+    describe '#start' do
+      it 'runs all on start if the :all_on_start option is set to true' do
         guard = described_class.new(:all_on_start => true)
         guard.should_receive(:run_all)
         guard.start
       end
 
-      it "does not run all on start if the :all_on_start option is set to false" do
+      it 'does not run all on start if the :all_on_start option is set to false' do
         guard = described_class.new(:all_on_start => false)
         guard.should_not_receive(:run_all)
         guard.start
       end
     end
 
-    describe "#respond_to" do
+    describe '#respond_to' do
       it { should respond_to :run_on_additions }
       it { should respond_to :run_on_modifications }
       it { should_not respond_to :run_on_change }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,7 @@
-require "bundler/setup"
-require "rspec/autorun"
+require 'bundler/setup'
+require 'rspec/autorun'
 
-ENV["GUARD_ENV"] = "test"
+ENV['GUARD_ENV'] = 'test'
 
 # Requires supporting files with custom matchers and macros, etc,
 # in ./support/ and its subdirectories.
@@ -9,5 +9,6 @@ Dir["#{File.dirname(__FILE__)}/support/**/*.rb"].each { |file| require file }
 
 RSpec.configure do |config|
   config.mock_framework = :rspec
-  config.treat_symbols_as_metadata_keys_with_true_values = true # default in RSpec 3
+  # default in RSpec 3
+  config.treat_symbols_as_metadata_keys_with_true_values = true
 end


### PR DESCRIPTION
Incorporates PRs from Nordstrom and Richard Nixon to make compatible with Guard 2.9 (now 2.12) and Foodcritic 4.

Also adds the templates dir and metadata.rb to files watched by the Guardfile snippet inserted by 'guard init foodcritic'
