### PR TITLE
fix for 0 for 1 error

### DIFF
--- a/lib/guard/foodcritic/templates/Guardfile
+++ b/lib/guard/foodcritic/templates/Guardfile
@@ -4,5 +4,5 @@ guard 'foodcritic' do
   watch(%r{recipes/.+\.rb$})
   watch(%r{resources/.+\.rb$})
   watch(%r{templates/.+$})
-  watch['metadata.rb']
+  watch('metadata.rb')
 end


### PR DESCRIPTION
This was a quick fix for the 0 for 1 error I was seeing.
Fixes https://github.com/Nordstrom/guard-foodcritic/issues/11