### PR TITLE
Depend on foodcritic 5.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,7 @@
 language: ruby
 rvm:
-  - "1.9.3-p551"
-  - "2.0.0-p598"
-  - "2.1.6"
-  - "2.2.2"
+  - "2.0.0-p647"
+  - "2.1.7"
+  - "2.2.3"
 install: bundle install --binstubs
 env: TRAVIS_BUILD=true
-matrix:
-  allow_failures:
-    - rvm: "1.9.3-p551"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Project History for guard-foodcritic
 
+## 2.0.0
+
+* depend on foodcritic ~> 5.0
+* remove support for ruby 1.9.3 (because foodcritic only works with Ruby 2.0.0+)
+
 ## 1.1.1
 
 * fix 0 for 1 error, patch from github/myappleguy

--- a/README.md
+++ b/README.md
@@ -12,13 +12,18 @@ Guard::Foodcritic automatically runs foodcritic.
 
 ## Installation
 
-Please be sure to have [Guard](https://github.com/guard/guard) installed before continuing.
+guard-foodcritic depends on foodcritic v5.x, which only works with Ruby
+v2.0.0 and higher.  If you are still using Ruby v1.9.3, you should use
+v1.1.1 of this gem.  The current best practice for running foodcritic
+against cookbooks is to use [ChefDK](https://downloads.chef.io/chef-dk/)
+for cookbook development, which includes Ruby 2.x.x on all platforms.
 
 Install the gem:
 
     $ gem install guard-foodcritic
 
-Add the guard-foodcritic definition to your Guardfile by running this command:
+Add the guard-foodcritic definition to your Guardfile by running this
+command:
 
     $ guard init foodcritic
 

--- a/guard-foodcritic.gemspec
+++ b/guard-foodcritic.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |gem|
 
   gem.add_runtime_dependency 'guard', '~> 2.12'
   gem.add_dependency 'guard-compat', '~> 1.1'
-  gem.add_runtime_dependency 'foodcritic', '~> 4.0'
+  gem.add_runtime_dependency 'foodcritic', '~> 5.0'
 
   gem.add_development_dependency 'rake', '~> 10.0'
   gem.add_development_dependency 'rspec', '~> 2.10'

--- a/lib/guard/foodcritic/version.rb
+++ b/lib/guard/foodcritic/version.rb
@@ -1,3 +1,3 @@
 module Guard
-  FOODCRITIC_VERSION = '1.1.1'
+  FOODCRITIC_VERSION = '2.0.0'
 end


### PR DESCRIPTION
Remove support for Ruby 1.9.3 because foodcritic requires Ruby 2.0.0 now
Version bump to 2.0.0