### PR TITLE
Use Foodcritic 7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: ruby
 rvm:
-  - 2.1.6
+  - 2.3.0
 sudo: false

--- a/guard-foodcritic.gemspec
+++ b/guard-foodcritic.gemspec
@@ -21,5 +21,5 @@ Gem::Specification.new do |gem|
 
   gem.add_development_dependency 'rake', '~> 11.0'
   gem.add_development_dependency 'rspec', '~> 3.4'
-  gem.add_development_dependency 'rubocop', '~> 0.39'
+  gem.add_development_dependency 'rubocop', '~> 0.39.0'
 end

--- a/guard-foodcritic.gemspec
+++ b/guard-foodcritic.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |gem|
 
   gem.add_runtime_dependency 'guard', '~> 2.12'
   gem.add_dependency 'guard-compat', '~> 1.2'
-  gem.add_runtime_dependency 'foodcritic', '~> 6.0'
+  gem.add_runtime_dependency 'foodcritic', '~> 7.0'
 
   gem.add_development_dependency 'rake', '~> 11.0'
   gem.add_development_dependency 'rspec', '~> 3.4'


### PR DESCRIPTION
This updates the gem to use foodcritic version `7`.

I also included some small fixes to avoid breaking Travis builds:
- a3fbaf2: Force to use RuboCop version `0.39.x`. Newer minor versions detect new/different offenses.
- 716018d: Build against Ruby `2.3.0`. Building against older versions gives errors about some dependencies requiring newer versions of Ruby. This also makes the tests run against the same version as the one included in the [`.ruby-version`](https://github.com/Nordstrom/guard-foodcritic/blob/master/.ruby-version) file.
- ~~aa6c501: Disable sudo in Travis. Not required.~~
